### PR TITLE
add black config

### DIFF
--- a/backend/app/.flake8
+++ b/backend/app/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 88
+max-line-length = 120
 exclude = .git,__pycache__,__init__.py,.mypy_cache,.pytest_cache

--- a/backend/app/app/api/api_v1/endpoints/items.py
+++ b/backend/app/app/api/api_v1/endpoints/items.py
@@ -22,9 +22,7 @@ def read_items(
     if crud.user.is_superuser(current_user):
         items = crud.item.get_multi(db, skip=skip, limit=limit)
     else:
-        items = crud.item.get_multi_by_owner(
-            db=db, owner_id=current_user.id, skip=skip, limit=limit
-        )
+        items = crud.item.get_multi_by_owner(db=db, owner_id=current_user.id, skip=skip, limit=limit)
     return items
 
 

--- a/backend/app/app/api/api_v1/endpoints/login.py
+++ b/backend/app/app/api/api_v1/endpoints/login.py
@@ -20,24 +20,18 @@ router = APIRouter()
 
 
 @router.post("/login/access-token", response_model=schemas.Token)
-def login_access_token(
-    db: Session = Depends(deps.get_db), form_data: OAuth2PasswordRequestForm = Depends()
-) -> Any:
+def login_access_token(db: Session = Depends(deps.get_db), form_data: OAuth2PasswordRequestForm = Depends()) -> Any:
     """
     OAuth2 compatible token login, get an access token for future requests
     """
-    user = crud.user.authenticate(
-        db, email=form_data.username, password=form_data.password
-    )
+    user = crud.user.authenticate(db, email=form_data.username, password=form_data.password)
     if not user:
         raise HTTPException(status_code=400, detail="Incorrect email or password")
     elif not crud.user.is_active(user):
         raise HTTPException(status_code=400, detail="Inactive user")
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     return {
-        "access_token": security.create_access_token(
-            user.id, expires_delta=access_token_expires
-        ),
+        "access_token": security.create_access_token(user.id, expires_delta=access_token_expires),
         "token_type": "bearer",
     }
 
@@ -63,9 +57,7 @@ def recover_password(email: str, db: Session = Depends(deps.get_db)) -> Any:
             detail="The user with this username does not exist in the system.",
         )
     password_reset_token = generate_password_reset_token(email=email)
-    send_reset_password_email(
-        email_to=user.email, email=email, token=password_reset_token
-    )
+    send_reset_password_email(email_to=user.email, email=email, token=password_reset_token)
     return {"msg": "Password recovery email sent"}
 
 

--- a/backend/app/app/api/api_v1/endpoints/users.py
+++ b/backend/app/app/api/api_v1/endpoints/users.py
@@ -45,9 +45,7 @@ def create_user(
         )
     user = crud.user.create(db, obj_in=user_in)
     if settings.EMAILS_ENABLED and user_in.email:
-        send_new_account_email(
-            email_to=user_in.email, username=user_in.email, password=user_in.password
-        )
+        send_new_account_email(email_to=user_in.email, username=user_in.email, password=user_in.password)
     return user
 
 
@@ -126,9 +124,7 @@ def read_user_by_id(
     if user == current_user:
         return user
     if not crud.user.is_superuser(current_user):
-        raise HTTPException(
-            status_code=400, detail="The user doesn't have enough privileges"
-        )
+        raise HTTPException(status_code=400, detail="The user doesn't have enough privileges")
     return user
 
 

--- a/backend/app/app/api/deps.py
+++ b/backend/app/app/api/deps.py
@@ -11,9 +11,7 @@ from app.core import security
 from app.core.config import settings
 from app.db.session import SessionLocal
 
-reusable_oauth2 = OAuth2PasswordBearer(
-    tokenUrl=f"{settings.API_V1_STR}/login/access-token"
-)
+reusable_oauth2 = OAuth2PasswordBearer(tokenUrl=f"{settings.API_V1_STR}/login/access-token")
 
 
 def get_db() -> Generator:
@@ -24,13 +22,9 @@ def get_db() -> Generator:
         db.close()
 
 
-def get_current_user(
-    db: Session = Depends(get_db), token: str = Depends(reusable_oauth2)
-) -> models.User:
+def get_current_user(db: Session = Depends(get_db), token: str = Depends(reusable_oauth2)) -> models.User:
     try:
-        payload = jwt.decode(
-            token, settings.SECRET_KEY, algorithms=[security.ALGORITHM]
-        )
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[security.ALGORITHM])
         token_data = schemas.TokenPayload(**payload)
     except (jwt.JWTError, ValidationError):
         raise HTTPException(
@@ -55,7 +49,5 @@ def get_current_active_superuser(
     current_user: models.User = Depends(get_current_user),
 ) -> models.User:
     if not crud.user.is_superuser(current_user):
-        raise HTTPException(
-            status_code=400, detail="The user doesn't have enough privileges"
-        )
+        raise HTTPException(status_code=400, detail="The user doesn't have enough privileges")
     return current_user

--- a/backend/app/app/core/config.py
+++ b/backend/app/app/core/config.py
@@ -71,11 +71,7 @@ class Settings(BaseSettings):
 
     @validator("EMAILS_ENABLED", pre=True)
     def get_emails_enabled(cls, v: bool, values: Dict[str, Any]) -> bool:
-        return bool(
-            values.get("SMTP_HOST")
-            and values.get("SMTP_PORT")
-            and values.get("EMAILS_FROM_EMAIL")
-        )
+        return bool(values.get("SMTP_HOST") and values.get("SMTP_PORT") and values.get("EMAILS_FROM_EMAIL"))
 
     EMAIL_TEST_USER: EmailStr = "test@example.com"  # type: ignore
     FIRST_SUPERUSER: EmailStr

--- a/backend/app/app/core/security.py
+++ b/backend/app/app/core/security.py
@@ -12,15 +12,11 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 ALGORITHM = "HS256"
 
 
-def create_access_token(
-    subject: Union[str, Any], expires_delta: timedelta = None
-) -> str:
+def create_access_token(subject: Union[str, Any], expires_delta: timedelta = None) -> str:
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(
-            minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
-        )
+        expire = datetime.utcnow() + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode = {"exp": expire, "sub": str(subject)}
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt

--- a/backend/app/app/crud/base.py
+++ b/backend/app/app/crud/base.py
@@ -26,9 +26,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
     def get(self, db: Session, id: Any) -> Optional[ModelType]:
         return db.query(self.model).filter(self.model.id == id).first()
 
-    def get_multi(
-        self, db: Session, *, skip: int = 0, limit: int = 100
-    ) -> List[ModelType]:
+    def get_multi(self, db: Session, *, skip: int = 0, limit: int = 100) -> List[ModelType]:
         return db.query(self.model).offset(skip).limit(limit).all()
 
     def create(self, db: Session, *, obj_in: CreateSchemaType) -> ModelType:
@@ -39,13 +37,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         db.refresh(db_obj)
         return db_obj
 
-    def update(
-        self,
-        db: Session,
-        *,
-        db_obj: ModelType,
-        obj_in: Union[UpdateSchemaType, Dict[str, Any]]
-    ) -> ModelType:
+    def update(self, db: Session, *, db_obj: ModelType, obj_in: Union[UpdateSchemaType, Dict[str, Any]]) -> ModelType:
         obj_data = jsonable_encoder(db_obj)
         if isinstance(obj_in, dict):
             update_data = obj_in

--- a/backend/app/app/crud/crud_item.py
+++ b/backend/app/app/crud/crud_item.py
@@ -9,9 +9,7 @@ from app.schemas.item import ItemCreate, ItemUpdate
 
 
 class CRUDItem(CRUDBase[Item, ItemCreate, ItemUpdate]):
-    def create_with_owner(
-        self, db: Session, *, obj_in: ItemCreate, owner_id: int
-    ) -> Item:
+    def create_with_owner(self, db: Session, *, obj_in: ItemCreate, owner_id: int) -> Item:
         obj_in_data = jsonable_encoder(obj_in)
         db_obj = self.model(**obj_in_data, owner_id=owner_id)
         db.add(db_obj)
@@ -19,16 +17,8 @@ class CRUDItem(CRUDBase[Item, ItemCreate, ItemUpdate]):
         db.refresh(db_obj)
         return db_obj
 
-    def get_multi_by_owner(
-        self, db: Session, *, owner_id: int, skip: int = 0, limit: int = 100
-    ) -> List[Item]:
-        return (
-            db.query(self.model)
-            .filter(Item.owner_id == owner_id)
-            .offset(skip)
-            .limit(limit)
-            .all()
-        )
+    def get_multi_by_owner(self, db: Session, *, owner_id: int, skip: int = 0, limit: int = 100) -> List[Item]:
+        return db.query(self.model).filter(Item.owner_id == owner_id).offset(skip).limit(limit).all()
 
 
 item = CRUDItem(Item)

--- a/backend/app/app/crud/crud_user.py
+++ b/backend/app/app/crud/crud_user.py
@@ -24,9 +24,7 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
         db.refresh(db_obj)
         return db_obj
 
-    def update(
-        self, db: Session, *, db_obj: User, obj_in: Union[UserUpdate, Dict[str, Any]]
-    ) -> User:
+    def update(self, db: Session, *, db_obj: User, obj_in: Union[UserUpdate, Dict[str, Any]]) -> User:
         if isinstance(obj_in, dict):
             update_data = obj_in
         else:

--- a/backend/app/app/main.py
+++ b/backend/app/app/main.py
@@ -4,9 +4,7 @@ from starlette.middleware.cors import CORSMiddleware
 from app.api.api_v1.api import api_router
 from app.core.config import settings
 
-app = FastAPI(
-    title=settings.PROJECT_NAME, openapi_url=f"{settings.API_V1_STR}/openapi.json"
-)
+app = FastAPI(title=settings.PROJECT_NAME, openapi_url=f"{settings.API_V1_STR}/openapi.json")
 
 # Set all CORS enabled origins
 if settings.BACKEND_CORS_ORIGINS:

--- a/backend/app/app/tests/api/api_v1/test_celery.py
+++ b/backend/app/app/tests/api/api_v1/test_celery.py
@@ -5,9 +5,7 @@ from fastapi.testclient import TestClient
 from app.core.config import settings
 
 
-def test_celery_worker_test(
-    client: TestClient, superuser_token_headers: Dict[str, str]
-) -> None:
+def test_celery_worker_test(client: TestClient, superuser_token_headers: Dict[str, str]) -> None:
     data = {"msg": "test"}
     r = client.post(
         f"{settings.API_V1_STR}/utils/test-celery/",

--- a/backend/app/app/tests/api/api_v1/test_items.py
+++ b/backend/app/app/tests/api/api_v1/test_items.py
@@ -5,9 +5,7 @@ from app.core.config import settings
 from app.tests.utils.item import create_random_item
 
 
-def test_create_item(
-    client: TestClient, superuser_token_headers: dict, db: Session
-) -> None:
+def test_create_item(client: TestClient, superuser_token_headers: dict, db: Session) -> None:
     data = {"title": "Foo", "description": "Fighters"}
     response = client.post(
         f"{settings.API_V1_STR}/items/",
@@ -22,9 +20,7 @@ def test_create_item(
     assert "owner_id" in content
 
 
-def test_read_item(
-    client: TestClient, superuser_token_headers: dict, db: Session
-) -> None:
+def test_read_item(client: TestClient, superuser_token_headers: dict, db: Session) -> None:
     item = create_random_item(db)
     response = client.get(
         f"{settings.API_V1_STR}/items/{item.id}",

--- a/backend/app/app/tests/api/api_v1/test_login.py
+++ b/backend/app/app/tests/api/api_v1/test_login.py
@@ -17,9 +17,7 @@ def test_get_access_token(client: TestClient) -> None:
     assert tokens["access_token"]
 
 
-def test_use_access_token(
-    client: TestClient, superuser_token_headers: Dict[str, str]
-) -> None:
+def test_use_access_token(client: TestClient, superuser_token_headers: Dict[str, str]) -> None:
     r = client.post(
         f"{settings.API_V1_STR}/login/test-token",
         headers=superuser_token_headers,

--- a/backend/app/app/tests/api/api_v1/test_users.py
+++ b/backend/app/app/tests/api/api_v1/test_users.py
@@ -9,9 +9,7 @@ from app.schemas.user import UserCreate
 from app.tests.utils.utils import random_email, random_lower_string
 
 
-def test_get_users_superuser_me(
-    client: TestClient, superuser_token_headers: Dict[str, str]
-) -> None:
+def test_get_users_superuser_me(client: TestClient, superuser_token_headers: Dict[str, str]) -> None:
     r = client.get(f"{settings.API_V1_STR}/users/me", headers=superuser_token_headers)
     current_user = r.json()
     assert current_user
@@ -20,9 +18,7 @@ def test_get_users_superuser_me(
     assert current_user["email"] == settings.FIRST_SUPERUSER
 
 
-def test_get_users_normal_user_me(
-    client: TestClient, normal_user_token_headers: Dict[str, str]
-) -> None:
+def test_get_users_normal_user_me(client: TestClient, normal_user_token_headers: Dict[str, str]) -> None:
     r = client.get(f"{settings.API_V1_STR}/users/me", headers=normal_user_token_headers)
     current_user = r.json()
     assert current_user
@@ -31,9 +27,7 @@ def test_get_users_normal_user_me(
     assert current_user["email"] == settings.EMAIL_TEST_USER
 
 
-def test_create_user_new_email(
-    client: TestClient, superuser_token_headers: dict, db: Session
-) -> None:
+def test_create_user_new_email(client: TestClient, superuser_token_headers: dict, db: Session) -> None:
     username = random_email()
     password = random_lower_string()
     data = {"email": username, "password": password}
@@ -49,9 +43,7 @@ def test_create_user_new_email(
     assert user.email == created_user["email"]
 
 
-def test_get_existing_user(
-    client: TestClient, superuser_token_headers: dict, db: Session
-) -> None:
+def test_get_existing_user(client: TestClient, superuser_token_headers: dict, db: Session) -> None:
     username = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=username, password=password)
@@ -68,9 +60,7 @@ def test_get_existing_user(
     assert existing_user.email == api_user["email"]
 
 
-def test_create_user_existing_username(
-    client: TestClient, superuser_token_headers: dict, db: Session
-) -> None:
+def test_create_user_existing_username(client: TestClient, superuser_token_headers: dict, db: Session) -> None:
     username = random_email()
     # username = email
     password = random_lower_string()
@@ -87,9 +77,7 @@ def test_create_user_existing_username(
     assert "_id" not in created_user
 
 
-def test_create_user_by_normal_user(
-    client: TestClient, normal_user_token_headers: Dict[str, str]
-) -> None:
+def test_create_user_by_normal_user(client: TestClient, normal_user_token_headers: Dict[str, str]) -> None:
     username = random_email()
     password = random_lower_string()
     data = {"email": username, "password": password}
@@ -101,9 +89,7 @@ def test_create_user_by_normal_user(
     assert r.status_code == 400
 
 
-def test_retrieve_users(
-    client: TestClient, superuser_token_headers: dict, db: Session
-) -> None:
+def test_retrieve_users(client: TestClient, superuser_token_headers: dict, db: Session) -> None:
     username = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=username, password=password)

--- a/backend/app/app/tests/conftest.py
+++ b/backend/app/app/tests/conftest.py
@@ -29,6 +29,4 @@ def superuser_token_headers(client: TestClient) -> Dict[str, str]:
 
 @pytest.fixture(scope="module")
 def normal_user_token_headers(client: TestClient, db: Session) -> Dict[str, str]:
-    return authentication_token_from_email(
-        client=client, email=settings.EMAIL_TEST_USER, db=db
-    )
+    return authentication_token_from_email(client=client, email=settings.EMAIL_TEST_USER, db=db)

--- a/backend/app/app/tests/utils/user.py
+++ b/backend/app/app/tests/utils/user.py
@@ -10,9 +10,7 @@ from app.schemas.user import UserCreate, UserUpdate
 from app.tests.utils.utils import random_email, random_lower_string
 
 
-def user_authentication_headers(
-    *, client: TestClient, email: str, password: str
-) -> Dict[str, str]:
+def user_authentication_headers(*, client: TestClient, email: str, password: str) -> Dict[str, str]:
     data = {"username": email, "password": password}
 
     r = client.post(f"{settings.API_V1_STR}/login/access-token", data=data)
@@ -30,9 +28,7 @@ def create_random_user(db: Session) -> User:
     return user
 
 
-def authentication_token_from_email(
-    *, client: TestClient, email: str, db: Session
-) -> Dict[str, str]:
+def authentication_token_from_email(*, client: TestClient, email: str, db: Session) -> Dict[str, str]:
     """
     Return a valid token for the user with given email.
 

--- a/backend/app/pyproject.toml
+++ b/backend/app/pyproject.toml
@@ -40,6 +40,11 @@ multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0
 line_length = 88
+
+[tool.black]
+skip-string-normalization = true
+line-length = 120
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
line length set to 120 characters since that is the length at which pycharm shows a line
skipping string normalizations since single quoted strings are good to signify strings being used as a specific argument e.g. when fetching value of a certain key from a dict

