### PR TITLE
docker-compose.yml: allow setting a custom path the docker socket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${TRAEFIK_PUBLIC_NETWORK?Variable not set}
       - default
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
     command:
       # Enable Docker in Traefik, so that it reads labels from Docker services
       - --providers.docker


### PR DESCRIPTION
For my rootless docker installation, its in /run/user/1000/docker.socket

This allows me to set that in my .env file

Signed-off-by: Akhil Narang <me@akhilnarang.dev>